### PR TITLE
No need to set upper limit on railties dependencies

### DIFF
--- a/knockoutjs-rails.gemspec
+++ b/knockoutjs-rails.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{lib,vendor}/**/*"] + ["MIT-LICENSE", "README.md"]
 
-  s.add_runtime_dependency "railties", [">= 3.1", "< 4.1"]
+  s.add_runtime_dependency "railties", [">= 3.1"]
 end


### PR DESCRIPTION
Make it work with Rails 4.1.0
